### PR TITLE
If the service key is an env variable, get the value from the jenkins…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pagerduty/util/PagerDutyUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/util/PagerDutyUtils.java
@@ -49,8 +49,11 @@ public class PagerDutyUtils {
 //            listener.getLogger().println("Unable to activate pagerduty module, check configuration!");
             return false;
         }
+
+        String serviceK = replaceEnvVars(pdparams.serviceKey, envv, null);
+
         if (pdparams.getIncidentKey() != null && pdparams.getIncidentKey().trim().length() > 0) {
-            ResolveIncident.ResolveIncidentBuilder resolveIncidentBuilder = ResolveIncident.ResolveIncidentBuilder.create(pdparams.getServiceKey(), pdparams.getIncidentKey());
+            ResolveIncident.ResolveIncidentBuilder resolveIncidentBuilder = ResolveIncident.ResolveIncidentBuilder.create(serviceK, pdparams.getIncidentKey());
             resolveIncidentBuilder.details(DEFAULT_RESOLVE_STR).description(DEFAULT_RESOLVE_DESC);
 
             ResolveIncident resolveIncident = resolveIncidentBuilder.build();


### PR DESCRIPTION
Hi Alexander,

Thank you for developing this plugin, we rely on it heavily. 

In our setup, the service key is defined in an environment variable rather than hardcoding it in each job, so that when we rotate the key, we can update this in a single place.

Raising an incident works fine, but when resolving an incident, the actual value of the service key is not determined from the jenkins env. 

This small fix addresses this problem.

Thanks,
Nick