### PR TITLE
Fix PagerDutyChangeEventStep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
+        <version>4.10</version>
         <relativePath />
     </parent>
     <artifactId>pagerduty</artifactId>
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
     <properties>
         <java.level>8</java.level>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <mavenVersion>3.3.9</mavenVersion>
     </properties>
     <name>PagerDuty Plugin</name>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>1.11</version>
+            <version>2.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyChangeEventStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyChangeEventStep.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 
 import org.jenkinsci.plugins.pagerduty.changeevents.ChangeEventSender;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -16,7 +17,8 @@ import hudson.model.TaskListener;
 /**
  * Workflow step for creating a PagerDuty Change Event.
  */
-public class PagerDutyChangeEventStep {
+public class PagerDutyChangeEventStep extends AbstractStepImpl {
+
   @Nonnull
   private final String integrationKey;
 


### PR DESCRIPTION
fixes #42 

This merge request corrects a bug in the `pagerdutyChangeEvent` pipeline step that prevented it from loading properly, and therefore unable to call in a pipeline job.  A stacktrace similar to below is seen on jenkins startup:

```
ec  8 16:33:49 ip-10-168-107-173 [jenkins]: 2020-12-08 16:33:49.073+0000 [id=34]#011WARNING#011h.ExtensionFinder$GuiceFinder$FaultTolerantScope$1#error: Failed to instantiate Key[type=org.jenkinsci.plugins.pagerduty.pipeline.PagerDutyChangeEventStep$DescriptorImpl, annotation=[none]]; skipping this component
Dec  8 16:33:49 ip-10-168-107-173 [jenkins]: java.lang.AssertionError: Outer class class org.jenkinsci.plugins.pagerduty.pipeline.PagerDutyChangeEventStep of class org.jenkinsci.plugins.pagerduty.pipeline.PagerDutyChangeEventStep$DescriptorImpl is not assignable to class org.jenkinsci.plugins.workflow.steps.Step. Perhaps wrong outer class?
Dec  8 16:33:49 ip-10-168-107-173 [jenkins]: #011at hudson.model.Descriptor.<init>(Descriptor.java:289)
```

This is testable via the following pipeline script:

```
 pipeline{
    agent any
    stages{
        stage("doit"){
            steps{
                pagerdutyChangeEvent(integrationKey: 'REDACTED')
                echo "blah"
                sleep 30
                pagerdutyChangeEvent(integrationKey: 'REDACTED')
            }
        }
    }
}
```
