### PR TITLE
adds support for tokenized strings in the PagerDuty Change Event freestyle step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>pagerduty</artifactId>
-    <version>0.6.3-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <java.level>8</java.level>


### PR DESCRIPTION
Minor fix to support tokenized strings.  Also bumps version to 0.7.0 completing the "Change Event enhancements".