### PR TITLE
Add a few basic ChangeEventBuilder unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,20 @@ Before you can use this plugin you'll need an **integration key** (also known as
 
 Once you have an integration key you can add the appropriate action to your Jenkins project and supply it with the integration key. Be sure to select which job results you want to send an event to PagerDuty.
 
+---
+## IMPORTANT!
 
+
+ **There is a beak in backwards compatibility between versions 4.x.x and 6.x.x**
+
+ if you are migrating from earlier versions to 6.x.x and above note the following changes:
+
+-    serviceKey is replaced with **routingKey**
+-    incidentKey is replaced with **dedupKey**
+-    incDescription/incDetails are replaced with **incidentSummary**
+-    please note the new fields introduced starting version 6.x.x
+
+---
 ### Pipeline
 
 #### Trigger/Resolve Incidents
@@ -103,8 +116,12 @@ shown below:
 
 ## Version History
 
-#### Version 0.x.x (Feb 28, 2021)
+#### Version 7.0.0 (Mar 31, 2021)
+(thanks [Bryan Bishop](https://github.com/bjbishop) and [Adam Krapfl](https://github.com/akrapfl)!)
+-   ChangeEvent custom summary text
+-   Support for tokenized strings in ChangeEvent 
 -   Freestyle job change events (Resolves JENKINS-64774 and #51)
+-   Bug Fixes
 
 #### Version 0.6.2 (Jan 03, 2021)
 -   Documentation Fix
@@ -120,6 +137,7 @@ shown below:
 #### Version 0.6.0 (Dec 06, 2020)
 -   Add **Change Events** support (thanks [Adam Vaughan](https://github.com/adamvaughan)!)
 -   Bug fixes
+-   <<< **THIS VERSION BREAKS BACKWARDS COMPATIBILITY WITH EARLIER VERSIONS** >>>
 
 #### Version 0.4.1 (Mar 12, 2019)
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>pagerduty</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.0</version>
     <packaging>hpi</packaging>
     <properties>
         <java.level>8</java.level>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/jenkinsci/pagerduty-plugin.git</connection>
         <developerConnection>scm:git:https://github.com/jenkinsci/pagerduty-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/pagerduty-plugin</url>
-        <tag>HEAD</tag>
+        <tag>pagerduty-0.7.0</tag>
     </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>display-url-api</artifactId>
             <version>2.3.3</version>
         </dependency>
-
+        
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
@@ -131,5 +131,25 @@
             <version>1.3.5</version>
             <scope>test</scope>
         </dependency>
+		
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.7</version>
+            <scope>test</scope>
+        </dependency> 
+
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>pagerduty</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <java.level>8</java.level>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/jenkinsci/pagerduty-plugin.git</connection>
         <developerConnection>scm:git:https://github.com/jenkinsci/pagerduty-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/pagerduty-plugin</url>
-        <tag>pagerduty-0.7.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <repositories>
         <repository>

--- a/src/test/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pagerduty/changeevents/ChangeEventBuilderTest.java
@@ -1,0 +1,170 @@
+package org.jenkinsci.plugins.pagerduty.changeevents;
+
+//import required libraries for mockito, junit and jenkins
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+
+import jenkins.model.Jenkins;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+
+import java.util.Map;
+import hudson.EnvVars;
+import java.io.IOException;
+import org.json.*;
+
+import java.io.IOException;
+
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+
+//power mockito to mock static method of classes
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ChangeEventsAPI.class, DisplayURLProvider.class})
+
+public class ChangeEventBuilderTest {
+	
+	 private static ChangeEventBuilder changeEventBuilder;
+	 private static  AbstractBuild build;
+	 private static  AbstractProject project;
+	 private static  AbstractProject job;
+	 private static  Jenkins jenkins;
+	 private static  Launcher launcher;
+	 private static  BuildListener listener;
+	 private static DisplayURLProvider urlProvider ;
+	 
+	 
+     // setup reusable objects across unit tests inside this method 
+	 @BeforeClass
+	public static void setupMessageBuilder() {
+		 
+		//mock jenkins objects and changeevent builder
+		build = mock(AbstractBuild.class);
+		project = mock(AbstractProject.class);
+		job = mock(AbstractProject.class);
+		jenkins = mock(Jenkins.class);
+		launcher = mock(Launcher.class);
+		listener = mock(BuildListener.class);
+		urlProvider = mock(DisplayURLProvider.class);
+		when(listener.getLogger()).thenReturn(System.out);
+
+	}
+	
+	//Unit test verifying JSON contains the job.getDisplayName() field
+	@Test
+	public void testBasicJsonFields() throws IOException {
+		ArgumentCaptor<String> jsonArg = ArgumentCaptor.forClass(String.class);
+
+		//static method mocks using PowerMockito
+		PowerMockito.mockStatic(ChangeEventsAPI.class);
+		when(ChangeEventsAPI.send(anyString())).thenReturn(new ChangeEventsAPI.Response(200, "OK"));
+		PowerMockito.mockStatic(DisplayURLProvider.class);
+		when(DisplayURLProvider.get()).thenReturn(urlProvider);
+
+		//The field we are testing
+		when(job.getDisplayName()).thenReturn("testjobname");
+		when(build.getNumber()).thenReturn(99);
+		changeEventBuilder = new ChangeEventBuilder("JUNIT_TEST_INTEGRATION_KEY");
+		changeEventBuilder.setSummaryText("testjobname built successfully");
+		when(urlProvider.get().getRunURL(build)).thenReturn("http://unitest-jenkins/job/testjobname/99/display/redirect");
+
+		//trigger build changeevent
+		changeEventBuilder.perform(build, launcher, listener);
+
+		//mock API call
+		PowerMockito.verifyStatic(ChangeEventsAPI.class, times(1));
+		ChangeEventsAPI.send(jsonArg.capture());
+		//Expecting jsonArg to contain a valid JSON string similar to the following
+		//{"payload":{"summary":"testjobname built successfully","source":"Jenkins","custom_details":{"duration":null,"build_number":0},"timestamp":"2021-03-17T21:45:24.808Z"},"links":[{"href":"http://www.testurl.com","text":"View on Jenkins"}],"routing_key":"testIntegration key"}
+
+		//Parse JSON and perform assertions
+		JSONObject sendBody = new JSONObject(jsonArg.getValue());
+		String href = sendBody.getJSONArray("links").getJSONObject(0).getString("href");
+		String summary = sendBody.getJSONObject("payload").getString("summary");
+		String routingKey = sendBody.getString("routing_key");
+		int buildNumber = sendBody.getJSONObject("payload").getJSONObject("custom_details").getInt("build_number");
+
+		assertEquals("http://unitest-jenkins/job/testjobname/99/display/redirect", href);
+		assertEquals("testjobname built successfully", summary);
+		assertEquals(99, buildNumber);
+		assertEquals("JUNIT_TEST_INTEGRATION_KEY", routingKey);
+	}
+
+	//Unit test verifying JSON contains the full URL of the job
+	@Test
+	public void testDefaultSummaryText() throws IOException {
+		ArgumentCaptor<String> jsonArg = ArgumentCaptor.forClass(String.class);
+
+		//static method mocks using PowerMockito
+		PowerMockito.mockStatic(ChangeEventsAPI.class);
+		when(ChangeEventsAPI.send(anyString())).thenReturn(new ChangeEventsAPI.Response(200, "OK"));
+		PowerMockito.mockStatic(DisplayURLProvider.class);
+		when(DisplayURLProvider.get()).thenReturn(urlProvider);
+
+		//The field required for testing
+		changeEventBuilder = new ChangeEventBuilder("JUNIT_TEST_INTEGRATION_KEY");
+		when(build.getFullDisplayName()).thenReturn("somepath/junit");
+		when(build.getDisplayName()).thenReturn("junit");
+		when(build.getDescription()).thenReturn("#99");
+		when(build.getResult()).thenReturn(Result.SUCCESS);
+
+		//trigger build changeevent
+		changeEventBuilder.perform(build, launcher, listener);
+
+		//mock API call
+		PowerMockito.verifyStatic(ChangeEventsAPI.class, times(1));
+		ChangeEventsAPI.send(jsonArg.capture());
+		//Expecting jsonArg to contain a valid JSON string similar to the following
+		//{"payload":{"summary":"testjobname built successfully","source":"Jenkins","custom_details":{"duration":null,"build_number":0},"timestamp":"2021-03-17T21:45:24.808Z"},"links":[{"href":"http://www.testurl.com","text":"View on Jenkins"}],"routing_key":"testIntegration key"}
+
+		//Parse JSON and perform assertions
+		JSONObject sendBody = new JSONObject(jsonArg.getValue());
+		String summary = sendBody.getJSONObject("payload").getString("summary");
+
+		assertEquals("somepath/junit#99: SUCCESS", summary);
+	} 
+
+// this is sample json
+//
+//	     ChangeEventsAPI.send("{\n"
+//			+ "  \"routing_key\": \"testIntegration key\",\n"
+//			+ "  \"payload\": {\n"
+//			+ "    \"summary\": \"test summary\",\n"
+//			+ "    \"timestamp\": \"2020-07-17T08:42:58.315+0000\",\n"
+//			+ "    \"source\": \"acme-build-pipeline-tool-default-i-9999\",\n"
+//			+ "    \"custom_details\": {\n"
+//			+ "      \"build_state\": \"passed\",\n"
+//			+ "      \"build_number\": \"2\",\n"
+//			+ "      \"run_time\": \"1236s\"\n"
+//			+ "    }\n"
+//			+ "  },\n"
+//			+ "  \"links\": [\n"
+//			+ "    {\n"
+//			+ "      \"href\": \"test url\",\n"
+//			+ "      \"text\": \"View more details in Acme!\"\n"
+//			+ "    }\n"
+//			+ "  ]\n"
+//			+ "}\n"
+//			+ "");
+	    
+	    
+}


### PR DESCRIPTION
Adds mockito/powermock libraries for unit testing, and implements a few basic unit tests against the ChangeEventBuilder class.

This PR also catches up @alexanderlz 's upstream repo with the 0.7.0 release notes.