### PR TITLE
JENKINS-68311 : Add config.jelly for pipeline snippet generator

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyChangeEventStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyChangeEventStep/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:include class="org.jenkinsci.plugins.pagerduty.changeevents.ChangeEventBuilder" page="config.jelly" />
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyTriggerStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pagerduty/pipeline/PagerDutyTriggerStep/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+  <st:include class="org.jenkinsci.plugins.pagerduty.PagerDutyTrigger" page="config.jelly" />
+</j:jelly>


### PR DESCRIPTION
This fixes [JENKINS-68311](https://issues.jenkins.io/browse/JENKINS-68311) and #61 - add support for the pipeline snippet generator page.

Before : 

![image](https://user-images.githubusercontent.com/88156386/164126876-92158e1f-aa41-4489-9073-4237cbcda334.png)


After :

![image](https://user-images.githubusercontent.com/88156386/164127480-6d6da264-15b0-4001-895d-19b1564f9799.png)
